### PR TITLE
Generate data through specific date instead of through file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "typescript": "^4.9.4",
+    "vite": "^4.2.1",
     "vitest": "^0.25.7"
   },
   "dependencies": {

--- a/src/holiday.ts
+++ b/src/holiday.ts
@@ -49,11 +49,13 @@ export class Holiday {
   }
 
   private parseYearJson(holiday_cn_json_schema: HolidayCnJsonSchema) {
-    const year: number = holiday_cn_json_schema.year
-
-    this.data[year] = new Map()
-
     holiday_cn_json_schema.days.forEach((holiday_json: HolidayJson) => {
+      const year = new Date(holiday_json.date).getFullYear()
+
+      if (this.data[year] === undefined) {
+        this.data[year] = new Map()
+      }
+
       this.data[year][holiday_json.date] = {
         name: holiday_json.name,
         type: holiday_json.isOffDay ? 'publicHoliday' : 'publicWorkday',

--- a/test/holiday.test.ts
+++ b/test/holiday.test.ts
@@ -37,4 +37,8 @@ describe('class', () => {
     expect(holiday.isPublicHoliday(new Date('2023-10-1'))).toBe(true)
     expect(holiday.publicHolidayName(new Date('2023-10-1'))).toBe('中秋节、国庆节')
   })
+
+  it('2023-12-31 is public holiday', () => {
+    expect(holiday.isPublicHoliday(new Date('2022-12-31'))).toBe(true)
+  })
 })


### PR DESCRIPTION
In upstream data, the New Year's Day holiday is usually included in the file for the next year. For example, '2022-12-13' would be in 2023.json. This will result in incorrect data being generated through the file name.